### PR TITLE
typo_utils.py

### DIFF
--- a/scripts/arkane/utils.py
+++ b/scripts/arkane/utils.py
@@ -219,7 +219,6 @@ def get_rmg_conformer(
             * 100
             * zpe_scale_factor
         )
-        scaled_zpe = 0
     else:
         scaled_zpe = 0
 


### PR DESCRIPTION
Typo in the code where scaled zpe is defined, but then overwritten as 0 right after.